### PR TITLE
Add logic to handle Algorand seeds

### DIFF
--- a/src/encoding/seed.js
+++ b/src/encoding/seed.js
@@ -1,0 +1,74 @@
+const base32 = require('hi-base32');
+const nacl = require('../nacl/naclWrappers');
+const utils = require('../utils/utils');
+
+const ALGORAND_SEED_BYTE_LENGTH = 36;
+const ALGORAND_CHECKSUM_BYTE_LENGTH = 4;
+const ALGORAND_SEED_LENGTH = 58;
+
+const MALFORMED_SEED_ERROR = new Error("seed seems to be malformed");
+
+/**
+ * Checks if a seed is valid
+ * @param {String} seed - encoded Algorand seed
+ * @returns {Boolean} true if valid, false otherwise
+ */
+function isValidSeed(seed) {
+  if (typeof seed !== "string") return false;
+
+  if (seed.length !== ALGORAND_SEED_LENGTH) return false;
+
+  // Try to decode
+  let decoded;
+  try {
+    decoded = decode(seed);
+  } catch (e) {
+    return false;
+  }
+
+  // Compute checksum
+  let checksum = nacl.genericHash(decoded.seed).slice(nacl.SEED_BYTES_LENGTH - ALGORAND_CHECKSUM_BYTE_LENGTH, nacl.SEED_BYTES_LENGTH);
+
+  // Check if the checksum and the seed are equal
+  return utils.arrayEqual(checksum, decoded.checksum);
+}
+
+/**
+ * @param seed
+ * @return {{checksum: Uint8Array, seed: Uint8Array}}
+ */
+function decode(seed) {
+  if (!(typeof seed === "string" || seed instanceof String)) throw MALFORMED_SEED_ERROR;
+
+  //try to decode
+  let decoded = base32.decode.asBytes(seed);
+
+  // Sanity check
+  if (decoded.length !== ALGORAND_SEED_BYTE_LENGTH) throw MALFORMED_SEED_ERROR;
+
+  return {
+    seed: new Uint8Array(decoded.slice(0, ALGORAND_SEED_BYTE_LENGTH - ALGORAND_CHECKSUM_BYTE_LENGTH)),
+    checksum: new Uint8Array(decoded.slice(nacl.SEED_BYTES_LENGTH, ALGORAND_SEED_BYTE_LENGTH))
+  }
+}
+
+/**
+ * Encode a secret key into a seed
+ * @param secretKey
+ * @return {String} encoded seed
+ */
+function encode(secretKey) {
+  // get seed
+  const seed = secretKey.slice(0,nacl.SEED_BYTES_LENGTH);
+  //compute checksum
+  const checksum = nacl.genericHash(seed).slice(nacl.SEED_BYTES_LENGTH - ALGORAND_CHECKSUM_BYTE_LENGTH, nacl.SEED_BYTES_LENGTH);
+  const encodedSeed = base32.encode(utils.concatArrays(seed, checksum));
+
+  return encodedSeed.toString().slice(0, ALGORAND_SEED_LENGTH); // removing the extra '===='
+}
+
+module.exports = {
+  isValidSeed,
+  decode,
+  encode
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 const nacl = require('./nacl/naclWrappers');
 const address = require('./encoding/address');
+const Seed = require('./encoding/seed');
 const mnemonic = require('./mnemonic/mnemonic');
 const encoding = require('./encoding/encoding');
 const txnBuilder = require('./transaction');
@@ -23,6 +24,29 @@ function generateAccount() {
     let keys = nacl.keyPair();
     let encodedPk = address.encode(keys.publicKey);
     return {addr: encodedPk, sk: keys.secretKey};
+}
+
+/**
+ * Generates an account (key pair) from a seed and returns a new Algorand
+ * address and its corresponding secret key
+ * @param {Uint8Array} [seed] - Algorand seed
+ * @returns {{sk: Uint8Array, addr: string}}
+ */
+function generateAccountFromSeed(seed) {
+    const keys = nacl.keyPairFromSeed(seed);
+    return {
+        addr: address.encode(keys.publicKey),
+        sk: keys.secretKey
+    };
+}
+
+/**
+ * Takes an Algorand seed and checks if valid
+ * @param {String} seed - Algorand seed
+ * @returns {Boolean} true if valid, false otherwise
+ */
+function isValidSeed(seed) {
+    return Seed.isValidSeed(seed);
 }
 
 /**
@@ -54,7 +78,7 @@ function mnemonicToSecretKey(mn) {
  */
 function secretKeyToMnemonic(sk) {
     // get the seed from the sk
-    let seed = sk.slice(0, nacl.SEED_BTYES_LENGTH);
+    let seed = sk.slice(0, nacl.SEED_BYTES_LENGTH);
     return mnemonic.mnemonicFromSeed(seed);
 }
 
@@ -201,15 +225,20 @@ function decodeObj(o) {
 
 module.exports = {
     isValidAddress,
+    isValidSeed,
     generateAccount,
+    generateAccountFromSeed,
     secretKeyToMnemonic,
     mnemonicToSecretKey,
     signTransaction,
     signBid,
     encodeObj,
     decodeObj,
+    address,
+    seed: Seed,
     Algod,
     Kmd,
+    nacl,
     mnemonicToMasterDerivationKey,
     masterDerivationKeyToMnemonic,
     appendSignMultisigTransaction,

--- a/src/mnemonic/mnemonic.js
+++ b/src/mnemonic/mnemonic.js
@@ -12,8 +12,8 @@ const ERROR_NOT_IN_WORDS_LIST = Error('the mnemonic contains a word that is not 
  */
 function mnemonicFromSeed(seed) {
     // Sanity length check
-    if (seed.length !== nacl.SEED_BTYES_LENGTH) {throw new RangeError("Seed length must be " +
-        nacl.SEED_BTYES_LENGTH);}
+    if (seed.length !== nacl.SEED_BYTES_LENGTH) {throw new RangeError("Seed length must be " +
+        nacl.SEED_BYTES_LENGTH);}
 
     const uint11Array = toUint11Array(seed);
     const words = applyWords(uint11Array);

--- a/src/nacl/naclWrappers.js
+++ b/src/nacl/naclWrappers.js
@@ -26,14 +26,18 @@ function sign(msg, secretKey) {
     return nacl.sign.detached(msg, secretKey);
 }
 
+function verify(msg, sig, publicKey) {
+    return nacl.sign.detached.verify(msg, sig, publicKey);
+}
+
 function bytesEqual(a, b) {
     return nacl.verify(a, b);
 }
 
-module.exports = {genericHash, randomBytes, keyPair, sign, keyPairFromSeed, keyPairFromSecretKey, bytesEqual};
+module.exports = {genericHash, randomBytes, keyPair, sign, verify, keyPairFromSeed, keyPairFromSecretKey, bytesEqual};
 
 // constants
 module.exports.PUBLIC_KEY_LENGTH = nacl.sign.publicKeyLength;
 module.exports.SECRET_KEY_LENGTH = nacl.sign.secretKeyLength;
 module.exports.HASH_BYTES_LENGTH = 32;
-module.exports.SEED_BTYES_LENGTH = 32;
+module.exports.SEED_BYTES_LENGTH = 32;

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -29,6 +29,16 @@ describe('Algosdk (AKA end to end)', function () {
         });
     });
 
+    describe('Key pair', function() {
+        it('should generate a key pair from a seed', function () {
+            const keyPair = algosdk.generateAccount();
+            const seed = keyPair.sk.slice(0, nacl.SEED_BYTES_LENGTH);
+            const regeneratedKeyPair = algosdk.generateAccountFromSeed(seed);
+            assert.equal(keyPair.addr, regeneratedKeyPair.addr);
+            assert.deepStrictEqual(keyPair.sk, regeneratedKeyPair.sk);
+        });
+    });
+
     describe('Sign', function () {
         it('should return a blob that matches the go code', function () {
             let sk = "advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor";

--- a/tests/8.Seed.js
+++ b/tests/8.Seed.js
@@ -1,0 +1,26 @@
+let assert = require('assert');
+let nacl = require("../src/nacl/naclWrappers");
+let Seed = require("../src/encoding/seed");
+
+describe('seed', function () {
+  describe('#isValid', function () {
+    it('should validate an encoded seed', function () {
+      const seed = nacl.randomBytes(32);
+      const encodedSeed = Seed.encode(seed);
+      assert.ok(Seed.isValidSeed(encodedSeed));
+    });
+
+    it('should fail to verify an invalid Algorand seed', function () {
+      assert.strictEqual(Seed.isValidSeed("MO2H6ZU47Q36GJ6GVHUKGEBEQINN7ZWVACMWZQGIYUOE3RBSRVYHV4ACJG"), false);
+    });
+  });
+
+  describe('encode, decode', function () {
+    it('should be able to encode and decode a seed', function () {
+      const seed = nacl.randomBytes(32);
+      const encodedSeed = Seed.encode(seed);
+      const decodedSeed = Seed.decode(encodedSeed);
+      assert.deepStrictEqual(new Uint8Array(decodedSeed.seed), seed);
+    });
+  });
+});


### PR DESCRIPTION
Adds logic for:
* Encode/decode Algorand seeds with base32 (needed for encrypting/decrypting with sjcl) 
* Generate a key pair from a seed
* Export `address` and `nacl` from the algosdk module (needed for signing messages/verifying signatures)